### PR TITLE
Dimmer class to support a dimmer WITHOUT a seperate relay

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # PyTeletask
 
-How to install
-==============
+# How to install
+
 Two standard ways: using pip or calling setup.py manually.
 With pip for Python 3 (http://www.pip-installer.org), simply do::
 
@@ -16,6 +16,10 @@ The other way: uncompress archive. Then calling setup.py directly boils down to:
 You can optionally add --user to install in your home.
 Please refer to distutils documentation for further details.
 
-Version 0.0.1
-=============
+# Version 0.0.1
+
 Initial release with basic functionality
+
+# Version 1.0.4
+
+Update with support for dimmer WITHOUT a seperate relay to turn a (dimmeable) light on/off.

--- a/pyteletask.egg-info/PKG-INFO
+++ b/pyteletask.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 2.1
 Name: pyteletask
-Version: 1.0.3
+Version: 1.0.4
 Summary: An Asynchronous Library for the Teletask protocol.
 Home-page: UNKNOWN
 Author: Timothy DE MEY

--- a/pyteletask.egg-info/SOURCES.txt
+++ b/pyteletask.egg-info/SOURCES.txt
@@ -14,8 +14,10 @@ teletask/core/telegram_queue.py
 teletask/devices/__init__.py
 teletask/devices/device.py
 teletask/devices/devices.py
+teletask/devices/dimmer.py
 teletask/devices/light.py
 teletask/devices/remote_value.py
+teletask/devices/remote_value_dimmer.py
 teletask/devices/remote_value_scaling.py
 teletask/devices/remote_value_switch.py
 teletask/devices/switch.py

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages, setup
 
 REQUIRES = []
-VERSION = '1.0.3'
+VERSION = '1.0.4'
 
 setup(
     name='pyteletask',

--- a/teletask/__version__.py
+++ b/teletask/__version__.py
@@ -1,3 +1,3 @@
 """Teletask version."""
 
-__version__ = "1.0.3"
+__version__ = "1.0.4"

--- a/teletask/devices/__init__.py
+++ b/teletask/devices/__init__.py
@@ -3,5 +3,8 @@ from .device import Device
 from .devices import Devices
 from .light import Light
 from .switch import Switch
+from .dimmer import Dimmer
 from .remote_value_switch import RemoteValueSwitch
+from .remote_value_scaling import RemoteValueScaling
+from .remote_value_dimmer import RemoteValueDimmer
 from .remote_value import RemoteValue

--- a/teletask/devices/dimmer.py
+++ b/teletask/devices/dimmer.py
@@ -1,0 +1,103 @@
+"""
+Module for managing a dimmer via Teletask.
+It provides functionality for
+* switching dimmer 'on' and 'off'.
+"""
+from .device import Device
+from .remote_value_dimmer import RemoteValueDimmer
+
+
+class Dimmer(Device):
+    """Class for managing a Dimmer."""
+
+    def __init__(self,
+                 teletask,
+                 name,
+                 group_address_brightness=None,
+                 doip_component="dimmer",
+                 device_updated_cb=None):
+        """Initialize Dimmer class."""
+        # pylint: disable=too-many-arguments
+        super(Dimmer, self).__init__(teletask, name, device_updated_cb)
+
+        self.doip_component = str(doip_component).upper()
+        self.teletask = teletask
+        self.light_state = False
+
+        self.dimmer = RemoteValueDimmer(
+            teletask,
+            group_address=group_address_brightness,
+            device_name=self.name,
+            after_update_cb=self.after_update,
+            range_from=0,
+            range_to=100,
+            doip_component="DIMMER")
+
+        self.teletask.register_device(self)
+
+    def __str__(self):
+        """Return object as readable string."""
+        str_brightness = '' if not self.supports_brightness else \
+            ' brightness="{0}"'.format(
+                self.dimmer.group_addr_str())
+
+        return '<Light name="{0}" ' \
+            'switch="{1}" {2} />' \
+            .format(
+                self.name,
+                self.dimmer.group_address,
+                str_brightness)
+
+    @property
+    def supports_brightness(self):
+        """Return if light supports brightness."""
+        return self.dimmer.initialized
+
+    @property
+    def state(self):
+        """Return the current switch state of the device."""
+        return self.dimmer.value != RemoteValueDimmer.Value.OFF
+
+    async def set_on(self):
+        """Switch light on."""
+        await self.dimmer.on()
+
+    async def set_off(self):
+        """Switch light off."""
+        await self.dimmer.off()
+
+    @property
+    def current_brightness(self):
+        """Return current brightness of light."""
+        return self.dimmer.value
+
+    async def set_brightness(self, brightness):
+        """Set brightness of light."""
+        if not self.supports_brightness:
+            self.teletask.logger.warning("Dimming not supported for device %s", self.get_name())
+            return
+        await self.dimmer.set(brightness)
+
+    async def change_state(self,value):
+        await self.dimmer.state(value)
+
+    async def current_state(self):
+        await self.dimmer.current_state()
+
+    async def do(self, action):
+        """Execute 'do' commands."""
+        if action == "on":
+            await self.set_on()
+        elif action == "off":
+            await self.set_off()
+        elif action.startswith("brightness:"):
+            await self.set_brightness(int(action[11:]))
+        else:
+            self.teletask.logger.debug("Could not understand action %s for device %s", action, self.get_name())
+
+    def has_group_address(self, var):
+        return False
+
+    def __eq__(self, other):
+        """Equal operator."""
+        return self.__dict__ == other.__dict__

--- a/teletask/devices/remote_value_dimmer.py
+++ b/teletask/devices/remote_value_dimmer.py
@@ -1,0 +1,53 @@
+"""
+Module for managing a Scaling remote value.
+DPT 5.001.
+"""
+from enum import Enum
+
+from .remote_value import RemoteValue
+from teletask.doip import TelegramSetting
+
+class RemoteValueDimmer(RemoteValue):
+    class Value(Enum):
+        """Enum for indicating the direction."""
+        OFF = 0
+        ON = 100
+
+    def __init__(self,
+                 teletask,
+                 group_address=None,
+                 device_name=None,
+                 after_update_cb=None,
+                 range_from=100,
+                 range_to=0,
+                 doip_component="DIMMER"):
+        """Abstraction for remote value of Dimmer."""
+        # pylint: disable=too-many-arguments
+        super(RemoteValueDimmer, self).__init__(
+            teletask, group_address=group_address,
+            device_name=device_name, after_update_cb=after_update_cb,
+            doip_component=doip_component)
+
+        self.range_from = range_from
+        self.range_to = range_to
+
+    def to_teletask(self, value):
+        """Convert value to payload."""
+        return value
+
+    def from_teletask(self, value):
+        """Convert current payload to value."""
+        return value
+
+    async def off(self):
+        """Set value to down."""
+        await self.set(self.Value.OFF.value)
+
+    async def on(self):
+        """Set value to UP."""
+        await self.set(self.Value.ON.value)
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement."""
+        return "%"

--- a/teletask/test.py
+++ b/teletask/test.py
@@ -3,24 +3,28 @@ import asyncio
 import random
 from teletask import Teletask
 from teletask.devices import Light
+from teletask.devices import Dimmer
 
 async def main():
     """Connect to KNX/IP bus, switch on light, wait 2 seconds and switch it off again."""
     doip = Teletask()
-    await doip.start("192.168.97.31",55957)
-    light = Light(doip,
-                  name='Stalamp',
+    await doip.start("192.168.1.101",55957)
+    
+    # light without dimmer
+    light1 = Light(doip,
+                  name='Stalamp1',
                   group_address_switch='32',
                   doip_component="relay")
-    await light.set_on()
+    await light1.set_on()
     await asyncio.sleep(1)
-    await light.set_on()
+    await light1.set_on()
     await asyncio.sleep(1)
-    await light.set_off()
+    await light1.set_off()
     await asyncio.sleep(1)
 
+    # light with dimmer WITH a seperate relay to turn a (dimmeable) light on/off.
     light2 = Light(doip,
-                name='Stalamp',
+                name='Stalamp2',
                 group_address_switch='32',
                 group_address_brightness='1',
                 doip_component="relay")
@@ -30,6 +34,19 @@ async def main():
     await asyncio.sleep(1)
     await light2.set_off()
     await asyncio.sleep(1)
+    
+    # new in v1.0.4 (using new Dimmer class)
+    # light with dimmer WITHOUT a seperate relay to turn a (dimmeable) light on/off.
+    light3 = Dimmer(doip,
+                name='Stalamp3',
+                group_address_brightness='5',
+                doip_component="dimmer")
+    await light3.set_on()
+    await asyncio.sleep(5)
+    await light3.set_brightness( int(random.uniform(0, 100)) )
+    await asyncio.sleep(5)
+    await light3.set_off()
+    await asyncio.sleep(5)
 
     await doip.stop()
 


### PR DESCRIPTION
Introduced a new Dimmer class to support a dimmer WITHOUT a seperate relay to turn a (dimmeable) light on/off.

In “./devices/”, introduced “dimmer.py”. This is a modified version of “light.py”.
• removed the “self.switch = RemoteValueSwitch(...” since in my setup there is no switch involved in the switching of a dimmer
• changed the “self.brightness = RemoteValueScaling(...” to “self.dimmer = RemoteValueDimmer(...”. And all references to “self.brightness“ have of course also been updates to “self.dimmer“.
• return value of “def state(self)” was changed to “return self.dimmer.value != RemoteValueDimmer.Value.OFF”. * I still have reservations about this, but it should work.

In “./devices/”, introduces “remote_value_dimmer.py”. This is basically a merged version of “remote_value_switch.py” and “remote_value_scaling.py”.
Note. There is one reservation in this file: the value ON. In a relay the return value is 255, couldn't yet find what the reurn value of a dimmer is. This might require an additional update. 

