### PR TITLE
Bug fix in devices/light.py, (re)added the missing class Value(Enum)

### DIFF
--- a/teletask/__version__.py
+++ b/teletask/__version__.py
@@ -1,3 +1,3 @@
 """Teletask version."""
 
-__version__ = "1.0.4"
+__version__ = "1.0.5"

--- a/teletask/devices/remote_value_dimmer.py
+++ b/teletask/devices/remote_value_dimmer.py
@@ -11,7 +11,7 @@ class RemoteValueDimmer(RemoteValue):
     class Value(Enum):
         """Enum for indicating the direction."""
         OFF = 0
-        ON = 100
+        ON = 255
 
     def __init__(self,
                  teletask,

--- a/teletask/devices/remote_value_switch.py
+++ b/teletask/devices/remote_value_switch.py
@@ -8,6 +8,11 @@ from .remote_value import RemoteValue
 from teletask.doip import TelegramSetting
 
 class RemoteValueSwitch(RemoteValue):
+    class Value(Enum):
+        """Enum for indicating the direction."""
+        OFF = 0
+        ON = 255
+
     def __init__(self,
                  teletask,
                  group_address=None,


### PR DESCRIPTION
I don't understand why, but... the "class Value(Enum)" was removed in "remote_value_switch.py" (v 1.0.4).

In 1.0.4, I didn't touch this file (even chekked in the pull request), yet this (sub)class was removed?

Anyway, in 1.0.5 this was again corrected (adding it again in "remote_value_switch.py").

